### PR TITLE
update min Intellij version and Gradle version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
 cache:
   directories:
     - $HOME/.gradle/caches/
@@ -20,11 +21,11 @@ jobs:
   include:
     - stage: Build and Test
       env: ORG_GRADLE_PROJECT_ideaVersion=LATEST-EAP-SNAPSHOT
-    - env: ORG_GRADLE_PROJECT_ideaVersion=2017.2.2
-    - env: ORG_GRADLE_PROJECT_ideaVersion=2017.1.5
+    - env: ORG_GRADLE_PROJECT_ideaVersion=2018.2.4
+    - env: ORG_GRADLE_PROJECT_ideaVersion=2018.1.5
     - stage: Deploy new Release
       script: skip
-      env: ORG_GRADLE_PROJECT_ideaVersion=2017.2.2
+      env: ORG_GRADLE_PROJECT_ideaVersion=2018.1
       deploy:
         - provider: script
           script: ./gradlew publishPlugin

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 }
 
 plugins {
-    id 'org.jetbrains.intellij' version '0.2.14'
+    id 'org.jetbrains.intellij' version '0.3.4'
 }
 
 version = "${version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,6 @@
 # https://www.jetbrains.com/intellij-repository/snapshots
 
 version = 1.3.0
-ideaVersion = 2017.1
+ideaVersion = 2018.1
 javaVersion = 1.8
 org.gradle.jvmargs=-XX:MaxPermSize=512m -XX:+CMSClassUnloadingEnabled -XX:+CMSPermGenSweepingEnabled -XX:+HeapDumpOnOutOfMemoryError -Xmx1024m -Dfile.encoding=utf-8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Aug 12 12:08:29 PDT 2017
+#Sat Oct 06 16:50:29 GMT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -56,7 +56,7 @@
     </change-notes>
 
     <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-    <idea-version since-build="171"/>
+    <idea-version since-build="181" until-build="191.*"/>
 
     <depends>com.intellij.modules.lang</depends>
     <depends>XPathView</depends>


### PR DESCRIPTION
not much to this PR.

- Sets supported Inteliij to 2018.1 - 2019.*
- updates Gradle version in wrapper
- updates gradle-intellij-plugin