### PR TITLE
update Gradle Wrapper, gradle-intellij-plugin, and GitHub Action

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,42 +18,48 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
+        ideaVersion: [ '2022.2', '2022.3', '2023.1', '2023.2', '2023.2.4' ]
+        experimental: [ false ]
         include:
-          - ideaVersion: LATEST-EAP-SNAPSHOT
-            experimental: true
-          - ideaVersion: 2021.3
-            experimental: false
-          - ideaVersion: 2021.2
-            experimental: false
+          - { ideaVersion: LATEST-EAP-SNAPSHOT, experimental: true }
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
       with:
-        java-version: '11'
-        distribution: 'adopt'
-    - name: Build with Gradle
-      uses: gradle/gradle-build-action@v2.0.1
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Build Plugin
+      uses: gradle/gradle-build-action@v2
       env:
         ORG_GRADLE_PROJECT_ideaVersion: ${{ matrix.ideaVersion }}
       with:
         arguments: buildPlugin
+
+    - name: Verify Plugin
+      uses: gradle/gradle-build-action@v2
+      env:
+          ORG_GRADLE_PROJECT_ideaVersion: ${{ matrix.ideaVersion }}
+      with:
+          arguments: verifyPlugin
 
   publish:
     needs: build
     environment: marketplace
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
       with:
-        java-version: '11'
-        distribution: 'adopt'
+        java-version: '17'
+        distribution: 'temurin'
     - name: Build with Gradle
-      uses: gradle/gradle-build-action@v2.0.1
+      uses: gradle/gradle-build-action@v2
       env:
         MARKETPLACE_TOKEN: ${{ secrets.MARKETPLACE_TOKEN }}
       with:

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
-    id 'org.jetbrains.intellij' version '0.7.3'
+    id 'org.jetbrains.intellij' version '1.16.0'
 }
 
 repositories {
@@ -12,13 +12,14 @@ apply plugin: 'java'
 sourceCompatibility = javaVersion
 targetCompatibility = javaVersion
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
     options.encoding = 'UTF-8'
-    options.compilerArgs << "-Xlint:deprecation"
 }
 
 // take the version number defined in 'gradle.properties' and use that in plugin.xml
-task initConfig(type: Copy) {
+tasks.register('initConfig', Copy) {
     from('src/main/resources') {
         include '**/plugin.xml'
         filter(ReplaceTokens, tokens: [version: version])
@@ -35,14 +36,18 @@ idea {
 
 apply plugin: 'org.jetbrains.intellij'
 intellij {
-    pluginName 'intellij-xslfo-support'
-    version ideaVersion
-    updateSinceUntilBuild false
-    plugins 'xpath' // the XPathView plugin is in a directory simply named xpath in Intellij IC and IU
+    pluginName = 'intellij-xslfo-support'
+    version = ideaVersion
+    updateSinceUntilBuild = false
+    downloadSources = !System.getenv().containsKey("CI") && 'IC' == type.get() // Only download sources when type is Intellij (required because no public source code is available for CLion)
+
+    plugins = ['xpath'] // the XPathView plugin is in a directory simply named xpath in Intellij IC and IU
 
     // SET YOUR JETBRAINS LOGIN DETAILS AS ENVIRONMENT VARIABLES SO THAT YOU CAN PUBLISH A NEW BUILD TO THE REPOSITORY
     publishPlugin {
-        token System.getenv('MARKETPLACE_TOKEN')
+        token = provider {
+            System.getenv('MARKETPLACE_TOKEN')
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,5 @@
 # https://www.jetbrains.com/intellij-repository/snapshots
 
 version = 1.3.2.1
-ideaVersion = 2021.3
-javaVersion = 11
+ideaVersion = 2022.2
+javaVersion = 17

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip

--- a/src/main/java/org/intellij/lang/xslfo/run/XslFoRunConfiguration.java
+++ b/src/main/java/org/intellij/lang/xslfo/run/XslFoRunConfiguration.java
@@ -30,7 +30,7 @@ import java.io.File;
 /**
  * @author Dmitry_Cherkas
  */
-public final class XslFoRunConfiguration extends LocatableConfigurationBase
+public final class XslFoRunConfiguration extends LocatableConfigurationBase<XslFoRunConfiguration>
     implements RunConfigurationWithSuppressedDefaultDebugAction, RunProfileWithCompileBeforeLaunchOption {
 
     private static final String NAME = "XSL-FO Configuration";
@@ -106,7 +106,7 @@ public final class XslFoRunConfiguration extends LocatableConfigurationBase
 
     @Override
     @SuppressWarnings({"unchecked"})
-    public void readExternal(Element element) throws InvalidDataException {
+    public void readExternal(@NotNull Element element) throws InvalidDataException {
         super.readExternal(element);
 
         Element e = element.getChild("XsltFile");
@@ -133,7 +133,7 @@ public final class XslFoRunConfiguration extends LocatableConfigurationBase
     }
 
     @Override
-    public void writeExternal(Element element) throws WriteExternalException {
+    public void writeExternal(@NotNull Element element) throws WriteExternalException {
         super.writeExternal(element);
 
         Element e = new Element("XsltFile");

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -4,7 +4,7 @@
     <name>XSL-FO Support</name>
     <version>@version@</version>
 
-    <vendor email="cherkas.da@gmail.com" url="https://github.com/dmitry-cherkas/intellij-xslfo-support" logo="/icons/fop-logo-32x32.png">
+    <vendor email="cherkas.da@gmail.com" url="https://github.com/dmitry-cherkas/intellij-xslfo-support">
         Dmitry Cherkas
     </vendor>
 
@@ -66,7 +66,7 @@
     </change-notes>
 
     <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-    <idea-version since-build="201"/>
+    <idea-version since-build="222" />
 
     <depends>com.intellij.modules.lang</depends>
     <depends>XPathView</depends>


### PR DESCRIPTION
- Update Gradle and the gradle-intellij-plugin (this requires some changes to build file)
- Update minimum supported Intellij version (which also requires JDK 17 now)
- Update github action to ensure build works across multiple Intellij versions up to current release
- Add missing type info to XslFoRunConfiguration